### PR TITLE
expose getNegotiatedVersion so it can be used by applications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 /.project
 /.settings/
 /.cproject
-/*.so
 /.libs/
 /*.slo
 /*.lo
 /*.o
+/*.so

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.project
+/.settings/
+/.cproject
 /*.so
-/base64.so

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/.project
+/*.so
+/base64.so

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 /.settings/
 /.cproject
 /*.so
+/.libs/
+/*.slo
+/*.lo
+/*.o

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-# Change this to point to your openssl source.
-OPENSSL_DIR=openssl
+# Change this to point to your openssl installation.
+OPENSSL_DIR=/usr/local
 CC=gcc
 CFLAGS=-Wall -Wextra -O3 -std=c99 -fpic -pthread -I$(OPENSSL_DIR)/include
 LDFLAGS=-L$(OPENSSL_DIR)/lib -lssl -lcrypto

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,15 @@
 OPENSSL_DIR=openssl
 CC=gcc
 CFLAGS=-Wall -Wextra -O3 -std=c99 -fpic -pthread -I$(OPENSSL_DIR)/include
+LDFLAGS=-L$(OPENSSL_DIR)/lib -lssl -lcrypto
 
 all: token_bind_client.so token_bind_server.so base64.so
 
 token_bind_client.so: token_bind_client.c token_bind_common.c token_bind_client.h token_bind_common.h tb_bytestring.h cbs.c cbb.c
-	$(CC) $(CFLAGS) -shared -o token_bind_client.so token_bind_client.c token_bind_common.c cbs.c cbb.c
+	$(CC) $(CFLAGS) -shared -o token_bind_client.so token_bind_client.c token_bind_common.c cbs.c cbb.c $(LDFLAGS)
 
 token_bind_server.so: token_bind_server.c token_bind_common.c token_bind_server.h token_bind_common.h tb_bytestring.h cbs.c cbb.c
-	$(CC) $(CFLAGS) -shared -o token_bind_server.so token_bind_server.c token_bind_common.c cbs.c cbb.c
+	$(CC) $(CFLAGS) -shared -o token_bind_server.so token_bind_server.c token_bind_common.c cbs.c cbb.c $(LDFLAGS)
 
 base64.so: base64.c base64.h
 	$(CC) $(CFLAGS) -shared -o base64.so base64.c

--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@ License File: LICENSE
 Description:  
 Provides support for token binding according to the following RFCs:
 
-https://tools.ietf.org/html/draft-ietf-tokbind-protocol-10  
-https://tools.ietf.org/html/draft-ietf-tokbind-negotiation-05  
-https://tools.ietf.org/html/draft-ietf-tokbind-https-06
+https://tools.ietf.org/html/draft-ietf-tokbind-protocol-18  
+https://tools.ietf.org/html/draft-ietf-tokbind-negotiation-10  
+https://tools.ietf.org/html/draft-ietf-tokbind-https-15
 
 This token binding library links to OpenSSL to provide token binding negotiation
 over TLS, and provides high level functions needed to add token binding support
-to HTTP appliactions.
+to HTTP applications.
 
 This is compatible with OpenSSL versions 1.1.0 and newer.  It is implemented
 using the custom extension API in OpenSSL.  Due to a minor issue
-(https://github.com/openssl/openssl/pull/927) in this API, resumption is not
-compatible with this token binding library unless a 1-line patch is made (see
-example/custom_ext_resume.patch).
+(https://github.com/openssl/openssl/pull/927) in this API, resumption in OpenSSL 1.1.0
+is not compatible with this token binding library unless a 1-line patch is made (see
+example/custom_ext_resume.patch). This patch should be included in OpenSSL >= 1.1.0.
 
 This is not an official Google product.

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,0 +1,5 @@
+/key_vault
+/*.so
+/cookie_jar
+/server
+/client

--- a/example/Makefile
+++ b/example/Makefile
@@ -1,10 +1,10 @@
-# Change this to point to your openssl source.
-OPENSSL_DIR=../openssl
+# Change this to point to your openssl installation.
+OPENSSL_DIR=/usr/local
 
 CC=gcc
 CFLAGS=-D_GNU_SOURCE -Wall -Wextra -O3 -std=c99 -fpic -pthread -I$(OPENSSL_DIR)/include -I..
 #CFLAGS=-D_GNU_SOURCE -Wall -Wextra -g -std=c99 -fpic -pthread -I$(OPENSSL_DIR)/include -I..
-LIBS= $(OPENSSL_DIR)/libssl.a $(OPENSSL_DIR)/libcrypto.a -ldl
+LIBS= $(OPENSSL_DIR)/lib/libssl.a $(OPENSSL_DIR)/lib/libcrypto.a -ldl
 
 all: client server unescape
 

--- a/example/Makefile
+++ b/example/Makefile
@@ -1,9 +1,9 @@
-# Change this to point to your openssl source.
-OPENSSL_DIR=../openssl
+# Change this to point to your openssl installation.
+OPENSSL_DIR=/usr/local
 
 CC=gcc
 CFLAGS=-D_GNU_SOURCE -Wall -Wextra -O3 -std=c99 -fpic -pthread -I$(OPENSSL_DIR)/include -I..
-LIBS= $(OPENSSL_DIR)/libssl.a $(OPENSSL_DIR)/libcrypto.a -ldl
+LIBS= $(OPENSSL_DIR)/lib/libssl.a $(OPENSSL_DIR)/lib/libcrypto.a -ldl
 
 all: client server
 

--- a/token_bind_common.c
+++ b/token_bind_common.c
@@ -198,7 +198,7 @@ static void setNegotiatedVersion(SSL* ssl, uint8_t major_version,
 /* getNegotiatedVersion retrieves the negotiated major and minor version from
    |ssl|.  The major version number is written to out[0], and and the minor
    version number is written to out[1]. */
-static void getNegotiatedVersion(SSL* ssl, uint8_t* out) {
+void getNegotiatedVersion(SSL* ssl, uint8_t* out) {
   uintptr_t version =
       (uintptr_t)SSL_get_ex_data(ssl, ssl_ex_data_index_negotiated_version);
   out[0] = version;

--- a/token_bind_common.h
+++ b/token_bind_common.h
@@ -156,4 +156,9 @@ bool tbSetPadding(tbKeyType key_type, EVP_PKEY_CTX* key_ctx);
 void tbHashTokenBindingID(const uint8_t* tokbind_id, size_t tokbind_id_len,
                           uint8_t hash_out[TB_HASH_LEN]);
 
+/* getNegotiatedVersion retrieves the negotiated major and minor version from
+   |ssl|.  The major version number is written to out[0], and and the minor
+   version number is written to out[1]. */
+void getNegotiatedVersion(SSL* ssl, uint8_t* out);
+
 #endif  /* TOKEN_BIND_CSRC_TOKEN_BIND_COMMON_H_ */

--- a/token_bind_common.h
+++ b/token_bind_common.h
@@ -46,7 +46,7 @@ enum tbTokenBindingType { TB_PROVIDED = 0, TB_REFERRED = 1 };
 /* Major/minor version numbers for the version of Token Binding negotiated over
    TLS.  The 0 major version means this is still experimental. */
 #define TB_MAJOR_VERSION 0
-#define TB_MINOR_VERSION 15
+#define TB_MINOR_VERSION 18
 
 /* Require this version to ensure that clients do not send the old formats. */
 #define TB_MIN_SUPPORTED_MAJOR_VERSION 0


### PR DESCRIPTION
useful for e.g. https://tools.ietf.org/html/draft-campbell-tokbind-ttrp